### PR TITLE
Hotfix/nonpos args

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,9 @@ Code contributions should be made in a new feature branch. After a feature is co
 This will follow the [semantic versioning scheme](https://semver.org/). If the changes are not reflected in the version number, please use `git tag`. See [this page](https://pyscaffold.org/en/stable/faq.html#best-practices-and-common-errors-with-version-numbers) for more information.
 
 ### Reviewing Code contributions
+
 As a reviewer please ensure the following is true:
-* Tests are funtional
+* Tests are functional
 * New Pull Request features are documented (i.e. docstrings and type hints)
 * the code is formatted with `ruff` and a line length of 79 characters per [PEP 8](https://peps.python.org/pep-0008/)
 
@@ -102,7 +103,8 @@ conda activate open_nipals
    repository. Try `tox -av` to see a list of the available checks.
 
 ### Testing
-Testing should begin with `pytest`  and, eventually, end with `tox`.
+
+Testing should begin with `pytest` and, eventually, end with `tox`.
 `pytest` will illuminate any issues with the code itself while `tox` will
 highlight dependency conflicts. It's *much* more expensive to run.
 
@@ -110,6 +112,15 @@ Prior to executing `tox` the first time, you will need to have all of the
 python environments specified in the [tox.ini](./tox.ini) file loaded. No
 need to build each combination, just a flat python 3.9, 3.10, 3.11, etc 
 environment will suffice; `tox` should detect that and then build from there.
+
+All PRs attempting to merge into the `main` branch of the public repository 
+will trigger a github actions pipeline running `flake8`-linting and `tox`. 
+Therefore, running `tox` is not strictly necessary for these kind of commits.
+However, if in doubt, please run `tox` locally before pushing to the public 
+repo. The github actions pipeline lives in the 
+(./github/workflows/python-app.py)-file. If new python versions are included 
+into the `tox` run, please do not only include them into the `tox.ini`, but 
+also in the python matrix in the workflow file.
 
 If you hit errors with `tox`, first try deleting the .tox folder.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ from open_nipals.nipalsPCA import NipalsPCA
 
 # data is the numpy data matrix generated in the preprocessing
 model = NipalsPCA()
-transformed_data = model.fit_transform(data)
+transformed_data = model.fit_transform(X=data)
 ```
 
 ### PLS
@@ -88,7 +88,7 @@ from open_nipals.nipalsPLS import NipalsPLS
 # note the X/Y data blocks would need to have
 # separate arrangeData and StandardScaler objects
 model = NipalsPLS()
-transformed_x_data, transformed_y_data = model.fit_transform(data_x, data_y)
+transformed_x_data, transformed_y_data = model.fit_transform(X=data_x, y=data_y)
 ```
 
 ## Distances
@@ -105,7 +105,7 @@ dmodx = model.calc_oomd(input_array = data, metric = "DModX")
 One particular feature of PLS models is that they can predict dependent variables. To this end, run `model.predict()`, where either a matrix of X data `input_x`, 
 or a matrix of X scores `scores_x` need to be given as arguments, e.g. 
 ```python
-predicted_y_data = model.predict(input_x=data_x)
+predicted_y_data = model.predict(X=data_x)
 ```
 
 

--- a/src/open_nipals/nipalsPCA.py
+++ b/src/open_nipals/nipalsPCA.py
@@ -19,13 +19,14 @@ from __future__ import (
     annotations,
 )  # needed so we can return NipalsPCA class in our type hints
 import numpy as np
+from sklearn.decomposition._base import _BasePCA
 import warnings
 from scipy.stats import f as F_dist
 from open_nipals.utils import _nan_mult
 from typing import Optional
 
 
-class NipalsPCA:
+class NipalsPCA(_BasePCA):
     """The custom-built class to use PCA using the NIPALS algorithm, i.e.,
     the same algorithm used in SIMCA.
 
@@ -265,14 +266,12 @@ class NipalsPCA:
 
         return self  # So methods can be chained
 
-    def transform(
-        self, input_array: np.ndarray, method: str = "naive"
-    ) -> np.ndarray:
+    def transform(self, X: np.ndarray, method: str = "naive") -> np.ndarray:
         """This function takes an input array and projects it based
         on a fitted model.
 
         Args:
-            input_array (np.ndarray): The nxm input array in the original
+            X (np.ndarray): The nxm input array in the original
                 feature space to be projected.
             method (str, optional): The method to use for the projection.
                 See reference listed in module docstring.
@@ -293,8 +292,8 @@ class NipalsPCA:
                 "Model has not yet been fit. Consider using fit_transform."
             )
 
-        # Extract shape of input_array
-        n, _ = input_array.shape
+        # Extract shape of X
+        n, _ = X.shape
 
         # Extract variables for simplicity
         num_lvs = self.n_components
@@ -302,7 +301,7 @@ class NipalsPCA:
 
         scores = np.zeros((n, num_lvs))
 
-        nan_mask = np.isnan(input_array)
+        nan_mask = np.isnan(X)
         nan_flag = np.any(nan_mask)
 
         if (not nan_flag) or (method == "naive"):
@@ -311,20 +310,18 @@ class NipalsPCA:
             for ind_lv in range(num_lvs):
                 if nan_flag:
                     scores[:, [ind_lv]] = _nan_mult(
-                        input_array,
+                        X,
                         loadings[:, [ind_lv]],
                         nan_mask,
                         use_denom=True,
                     )
                 else:
-                    scores[:, [ind_lv]] = input_array @ loadings[:, [ind_lv]]
+                    scores[:, [ind_lv]] = X @ loadings[:, [ind_lv]]
                     scores[:, [ind_lv]] = scores[:, [ind_lv]] / (
                         loadings[:, [ind_lv]].T @ loadings[:, [ind_lv]]
                     )
                 # deflate input data
-                input_array = (
-                    input_array - scores[:, [ind_lv]] @ loadings[:, [ind_lv]].T
-                )
+                X = X - scores[:, [ind_lv]] @ loadings[:, [ind_lv]].T
 
         elif nan_flag and (method == "projection"):
             # uses approach described in section 4 of McGregor paper
@@ -336,8 +333,7 @@ class NipalsPCA:
                     @ loadings[not_null, :num_lvs]
                 )  # denominator in eq. 9
                 nom = (
-                    loadings[not_null, :num_lvs].T
-                    @ input_array[row, not_null].T
+                    loadings[not_null, :num_lvs].T @ X[row, not_null].T
                 )  # nominator in eq. 9
                 scores[row, :] = (denom @ nom).T
 
@@ -372,23 +368,19 @@ class NipalsPCA:
                     S22 = P[not_null, :] @ theta @ P[not_null, :].T
 
                     # compute an estimate for the missing data
-                    z_hash = (
-                        S12 @ np.linalg.inv(S22) @ input_array[row, not_null].T
-                    )
-                    input_array[row, is_null] = z_hash
+                    z_hash = S12 @ np.linalg.inv(S22) @ X[row, not_null].T
+                    X[row, is_null] = z_hash
 
-                scores[row, :] = (P.T @ input_array[row, :].T)[
-                    0 : self.n_components
-                ]
+                scores[row, :] = (P.T @ X[row, :].T)[0 : self.n_components]
 
         # Give the people what they want!
         return scores
 
-    def fit(self, input_array: np.ndarray, verbose: bool = False) -> NipalsPCA:
+    def fit(self, X: np.ndarray, verbose: bool = False) -> NipalsPCA:
         """Fits PCA model to input data.
 
         Args:
-            input_array (np.ndarray): The input data to fit on.
+            X (np.ndarray): The input data to fit on.
             verbose (bool, optional): Whether or not to print out additional
                 convergence information. Defaults to False.
 
@@ -401,7 +393,7 @@ class NipalsPCA:
                 + " Try set_components() or build a new model object."
             )
         # n is the number of observations, m the number of variables/features
-        self.fit_data = np.copy(input_array)
+        self.fit_data = np.copy(X)
 
         self._add_components(n_add=self.n_components, verbose=verbose)
 
@@ -409,7 +401,7 @@ class NipalsPCA:
         return self
 
     def fit_transform(
-        self, input_array: np.ndarray, verbose: bool = False
+        self, X: np.ndarray, verbose: bool = False
     ) -> np.ndarray:
         """Fit, then transform input data.
 
@@ -419,7 +411,7 @@ class NipalsPCA:
         >>>> P.fit(X)
         >>>> T = P.transform(X)
         Args:
-            input_array (np.ndarray): The The input data to fit on and
+            X (np.ndarray): The The input data to fit on and
                 to transform.
             verbose (bool, optional): Whether or not to print out additional
                 convergence information. Defaults to False.
@@ -431,7 +423,7 @@ class NipalsPCA:
             np.ndarray: The corresponding scores.
         """
         if self.fitted_components == 0:
-            self.fit(input_array, verbose=verbose)
+            self.fit(X, verbose=verbose)
             scores = self.fit_scores.copy()
 
             return scores
@@ -440,11 +432,11 @@ class NipalsPCA:
                 "Model has already been fit. Try transform instead."
             )
 
-    def inverse_transform(self, input_scores: np.ndarray) -> np.ndarray:
+    def inverse_transform(self, X: np.ndarray) -> np.ndarray:
         """Approximate original data from scores.
 
         Args:
-            input_scores (np.ndarray): An array containing the scores.
+            X (np.ndarray): An array containing the scores.
 
         Raises:
             ValueError: PCA model has not been fit yet.
@@ -460,18 +452,18 @@ class NipalsPCA:
                 + "Try fit() or fit_transform() instead."
             )
 
-        # Check size of input_scores:
-        _, m = input_scores.shape
+        # Check size of X:
+        _, m = X.shape
 
         if m != self.n_components:
             raise ValueError(
-                "input_scores has number of columns different than number"
+                "X has number of columns different than number"
                 + " of components in model"
             )
 
         # self.n_components as we may have built loadings to a larger n than
         # the current number of components.
-        out_data = input_scores @ self.loadings[:, : self.n_components].T
+        out_data = X @ self.loadings[:, : self.n_components].T
 
         return out_data
 

--- a/src/open_nipals/nipalsPCA.py
+++ b/src/open_nipals/nipalsPCA.py
@@ -19,14 +19,13 @@ from __future__ import (
     annotations,
 )  # needed so we can return NipalsPCA class in our type hints
 import numpy as np
-from sklearn.decomposition._base import _BasePCA
 import warnings
 from scipy.stats import f as F_dist
 from open_nipals.utils import _nan_mult
 from typing import Optional
 
 
-class NipalsPCA(_BasePCA):
+class NipalsPCA:
     """The custom-built class to use PCA using the NIPALS algorithm, i.e.,
     the same algorithm used in SIMCA.
 

--- a/src/open_nipals/nipalsPLS.py
+++ b/src/open_nipals/nipalsPLS.py
@@ -404,7 +404,7 @@ class NipalsPLS(_PLS):
             scores_x = self._transform_xy(
                 X, self.loadings_x, weights=self.weights_x
             )
-            scores_y = self._transform_XY(input_y, self.loadings_y)
+            scores_y = self._transform_xy(y, self.loadings_y)
             return scores_x, scores_y
 
     def _transform_xy(

--- a/src/open_nipals/nipalsPLS.py
+++ b/src/open_nipals/nipalsPLS.py
@@ -24,13 +24,12 @@ from __future__ import (
     annotations,
 )  # needed so we can return NipalsPLS class in our type hints
 import numpy as np
-from sklearn.cross_decomposition._pls import _PLS
 import warnings
 from open_nipals.utils import _nan_mult
 from typing import Optional, Tuple, Union
 
 
-class NipalsPLS(_PLS):
+class NipalsPLS:
     def __init__(
         self,
         n_components: int = 2,
@@ -63,11 +62,11 @@ class NipalsPLS(_PLS):
         self.fit_data_x = None  # n_rows_x x n_cols_x
         self.fit_data_y = None  # n_rows_y x n_cols_y
 
-        self.loadings_X = None  # n_cols_x x n_components
+        self.loadings_x = None  # n_cols_x x n_components
         self.fit_scores_x = None  # n_rows_x x n_components
-        self.weights_X = None  # n_cols_x x n_components
+        self.weights_x = None  # n_cols_x x n_components
 
-        self.loadings_Y = None  # n_cols_y x n_components
+        self.loadings_y = None  # n_cols_y x n_components
         self.fit_scores_y = None  # n_rows_y x n_components
 
         self.regression_matrix = None  # n_components x n_predictors
@@ -85,8 +84,8 @@ class NipalsPLS(_PLS):
         Returns:
             int
         """
-        if self.loadings_X is not None:
-            return self.loadings_X.shape[1]
+        if self.loadings_x is not None:
+            return self.loadings_x.shape[1]
         else:
             return 0
 
@@ -163,7 +162,7 @@ class NipalsPLS(_PLS):
             input_y = input_y - sim_data_y
 
             p = np.append(
-                self.loadings_X, np.zeros((n_cols_x, n_add)), axis=1
+                self.loadings_x, np.zeros((n_cols_x, n_add)), axis=1
             )  # x loadings
             t = np.append(
                 self.fit_scores_x, np.zeros((n_rows_x, n_add)), axis=1
@@ -172,10 +171,10 @@ class NipalsPLS(_PLS):
                 self.fit_scores_y, np.zeros((n_rows_x, n_add)), axis=1
             )  # y scores
             w = np.append(
-                self.weights_X, np.zeros((n_cols_x, n_add)), axis=1
+                self.weights_x, np.zeros((n_cols_x, n_add)), axis=1
             )  # weights
             q = np.append(
-                self.loadings_Y, np.zeros((n_cols_y, n_add)), axis=1
+                self.loadings_y, np.zeros((n_cols_y, n_add)), axis=1
             )  # y loading
             b = np.zeros(
                 (fitted_components + n_add, fitted_components + n_add)
@@ -289,10 +288,10 @@ class NipalsPLS(_PLS):
             # End of for loop
 
         self.fit_scores_x = t
-        self.loadings_X = p
-        self.weights_X = w
+        self.loadings_x = p
+        self.weights_x = w
         self.fit_scores_y = u
-        self.loadings_Y = q
+        self.loadings_y = q
         self.regression_matrix = b
 
     def set_components(self, n_component: int, verbose: bool = False):
@@ -393,22 +392,22 @@ class NipalsPLS(_PLS):
         """
 
         # Check whether the model is available or not
-        if self.loadings_X is None:
+        if self.loadings_x is None:
             raise ValueError("Model has not yet been fit.")
 
         if input_y is None:
-            scores_x = self._transform_XY(
-                input_x, self.loadings_X, weights=self.weights_X
+            scores_x = self._transform_xy(
+                input_x, self.loadings_x, weights=self.weights_x
             )
             return scores_x
         else:
-            scores_x = self._transform_XY(
-                input_x, self.loadings_X, weights=self.weights_X
+            scores_x = self._transform_xy(
+                input_x, self.loadings_x, weights=self.weights_x
             )
-            scores_y = self._transform_XY(input_y, self.loadings_Y)
+            scores_y = self._transform_xy(input_y, self.loadings_y)
             return scores_x, scores_y
 
-    def _transform_XY(
+    def _transform_xy(
         self,
         input_array: np.array,
         loadings: np.array,
@@ -618,7 +617,7 @@ class NipalsPLS(_PLS):
 
         # self.n_components as we may have built loadings to a larger n than
         # the current number of components
-        out_data_x = input_scores_x @ self.loadings_X[:, : self.n_components].T
+        out_data_x = input_scores_x @ self.loadings_x[:, : self.n_components].T
 
         return out_data_x
 
@@ -705,7 +704,7 @@ class NipalsPLS(_PLS):
         """
 
         # Check whether the model is available or not
-        if self.loadings_X is None:
+        if self.loadings_x is None:
             raise ValueError("Model has not yet been fit")
 
         # Handle different inputs, either scores or raw data
@@ -717,7 +716,7 @@ class NipalsPLS(_PLS):
             pred_y = (
                 scores_x[:, :num_lvs]
                 @ self.regression_matrix[:num_lvs, :num_lvs]
-                @ self.loadings_Y[:, :num_lvs].T
+                @ self.loadings_y[:, :num_lvs].T
             )
         else:
             # if no scores, but input_x, calculate scores and re-call func
@@ -737,11 +736,11 @@ class NipalsPLS(_PLS):
         """
 
         # Check whether the model is available or not
-        if self.loadings_X is None:
+        if self.loadings_x is None:
             raise ValueError("Model has not yet been fit")
 
-        reg_vects = self.weights_X @ (
-            self.regression_matrix @ self.loadings_Y.T
+        reg_vects = self.weights_x @ (
+            self.regression_matrix @ self.loadings_y.T
         )
 
         return reg_vects

--- a/tests/test_nipalsPCA.py
+++ b/tests/test_nipalsPCA.py
@@ -110,7 +110,7 @@ def fitted_model_pass_dat(x: np.ndarray) -> Tuple[NipalsPCA, StandardScaler]:
     scaler_x, dat_x_scaled = init_scaler(x)
 
     pca_model = NipalsPCA(mean_centered=True)  # pylint: disable=not-callable
-    pca_model.fit(dat_x_scaled)
+    pca_model.fit(input_array=dat_x_scaled)
     return pca_model, scaler_x
 
 
@@ -135,7 +135,7 @@ class TestSubFuncs(unittest.TestCase):
         model = NipalsPCA().fit(self.data_scaled)
 
         with self.assertRaises(BaseException) as e:
-            model.fit(self.data_scaled)
+            model.fit(input_array=self.data_scaled)
 
             with self.subTest():
                 self.assertIn(
@@ -192,7 +192,9 @@ class TestFit(unittest.TestCase):
         model = self.model[0]
         scaler_x = self.model[1]
         input_data = self.X
-        py_calc_scores = model.transform(scaler_x.transform(input_data))
+        py_calc_scores = model.transform(
+            input_array=scaler_x.transform(input_data)
+        )
         test_val = rmse(model.fit_scores, py_calc_scores)
         lin_val = nan_conc_coeff(model.fit_scores, py_calc_scores)
         with self.subTest():
@@ -233,7 +235,9 @@ class TestFit(unittest.TestCase):
         input_data = self.X
         metric, known_oomd = self.oomd
         transformed_data = scaler_x.transform(input_data)
-        test_oomd = model.calc_oomd(transformed_data, metric=metric)
+        test_oomd = model.calc_oomd(
+            input_array=transformed_data, metric=metric
+        )
         test_val = rmse(test_oomd, known_oomd)
         lin_val = nan_conc_coeff(test_oomd, known_oomd)
 
@@ -252,7 +256,7 @@ class TestFit(unittest.TestCase):
         model_low.fit(transformed_data)
         # Update to new amount of components
         num_lvs = model.n_components
-        model_low.set_components(num_lvs)
+        model_low.set_components(n_component=num_lvs)
 
         # Demonstrate loadings/scores are the same
         max_score_diff = np.max(
@@ -274,8 +278,8 @@ class TestFit(unittest.TestCase):
             )
 
         # Add an extra component, drop back down
-        model_low.set_components(num_lvs + 1)
-        model_low.set_components(num_lvs)
+        model_low.set_components(n_component=num_lvs + 1)
+        model_low.set_components(n_component=num_lvs)
 
         # Same loadings/scores test to ensure they didn't change
         max_score_diff = np.max(
@@ -303,8 +307,8 @@ class TestFit(unittest.TestCase):
         test_imd = model_low.calc_imd(input_array=model_low.fit_data)
         max_imd_diff = np.max(np.abs(known_imd - test_imd))
 
-        known_oomd = model.calc_oomd(model.fit_data)
-        test_oomd = model_low.calc_oomd(model_low.fit_data)
+        known_oomd = model.calc_oomd(input_array=model.fit_data)
+        test_oomd = model_low.calc_oomd(input_array=model_low.fit_data)
         max_oomd_diff = np.max(np.abs(known_oomd - test_oomd))
 
         with self.subTest():

--- a/tests/test_nipalsPCA.py
+++ b/tests/test_nipalsPCA.py
@@ -110,7 +110,7 @@ def fitted_model_pass_dat(x: np.ndarray) -> Tuple[NipalsPCA, StandardScaler]:
     scaler_x, dat_x_scaled = init_scaler(x)
 
     pca_model = NipalsPCA(mean_centered=True)  # pylint: disable=not-callable
-    pca_model.fit(input_array=dat_x_scaled)
+    pca_model.fit(X=dat_x_scaled)
     return pca_model, scaler_x
 
 
@@ -135,7 +135,7 @@ class TestSubFuncs(unittest.TestCase):
         model = NipalsPCA().fit(self.data_scaled)
 
         with self.assertRaises(BaseException) as e:
-            model.fit(input_array=self.data_scaled)
+            model.fit(X=self.data_scaled)
 
             with self.subTest():
                 self.assertIn(
@@ -192,9 +192,7 @@ class TestFit(unittest.TestCase):
         model = self.model[0]
         scaler_x = self.model[1]
         input_data = self.X
-        py_calc_scores = model.transform(
-            input_array=scaler_x.transform(input_data)
-        )
+        py_calc_scores = model.transform(X=scaler_x.transform(input_data))
         test_val = rmse(model.fit_scores, py_calc_scores)
         lin_val = nan_conc_coeff(model.fit_scores, py_calc_scores)
         with self.subTest():

--- a/tests/test_nipalsPLS_RandomGen.py
+++ b/tests/test_nipalsPLS_RandomGen.py
@@ -108,7 +108,7 @@ def fitted_model_pass_dat(
     scaler_x, dat_x_scaled = init_scaler(x)
     scaler_y, dat_y_scaled = init_scaler(y)
     pls_model = NipalsPLS(mean_centered=True)  # pylint: disable=not-callable
-    pls_model.fit(input_x=dat_x_scaled, input_y=dat_y_scaled)
+    pls_model.fit(X=dat_x_scaled, y=dat_y_scaled)
     return pls_model, scaler_x, scaler_y
 
 
@@ -222,13 +222,9 @@ class TestFit(unittest.TestCase):
         if "NaN" in self.name:
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore")
-                py_calc_scores = model.transform(
-                    input_x=scaler_x.transform(in_data)
-                )
+                py_calc_scores = model.transform(X=scaler_x.transform(in_data))
         else:
-            py_calc_scores = model.transform(
-                input_x=scaler_x.transform(in_data)
-            )
+            py_calc_scores = model.transform(X=scaler_x.transform(in_data))
 
         test_val = rmse(model.fit_scores_x, py_calc_scores)
         lin_val = nan_conc_coeff(model.fit_scores_x, py_calc_scores)
@@ -258,7 +254,7 @@ class TestFit(unittest.TestCase):
         """
         py_y_vals = self.model[0].predict(scores_x=self.T)
         py_y_vals = self.model[2].inverse_transform(
-            py_y_vals
+            X=py_y_vals
         )  # reverse standardscaling
         test_val = rmse(self.yhat, py_y_vals)
         lin_val = nan_conc_coeff(self.yhat, py_y_vals)
@@ -356,7 +352,7 @@ class TestFit(unittest.TestCase):
             transformed_data_y = scaler_y.transform(self.Y)
 
         model_low = NipalsPLS(n_components=1)
-        model_low.fit(input_x=transformed_data_x, input_y=transformed_data_y)
+        model_low.fit(X=transformed_data_x, y=transformed_data_y)
 
         # Update to new amount of components
         num_lvs = model.n_components

--- a/tests/test_nipalsPLS_RandomGen.py
+++ b/tests/test_nipalsPLS_RandomGen.py
@@ -108,7 +108,7 @@ def fitted_model_pass_dat(
     scaler_x, dat_x_scaled = init_scaler(x)
     scaler_y, dat_y_scaled = init_scaler(y)
     pls_model = NipalsPLS(mean_centered=True)  # pylint: disable=not-callable
-    pls_model.fit(dat_x_scaled, dat_y_scaled)
+    pls_model.fit(input_x=dat_x_scaled, input_y=dat_y_scaled)
     return pls_model, scaler_x, scaler_y
 
 
@@ -222,9 +222,13 @@ class TestFit(unittest.TestCase):
         if "NaN" in self.name:
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore")
-                py_calc_scores = model.transform(scaler_x.transform(in_data))
+                py_calc_scores = model.transform(
+                    input_x=scaler_x.transform(in_data)
+                )
         else:
-            py_calc_scores = model.transform(scaler_x.transform(in_data))
+            py_calc_scores = model.transform(
+                input_x=scaler_x.transform(in_data)
+            )
 
         test_val = rmse(model.fit_scores_x, py_calc_scores)
         lin_val = nan_conc_coeff(model.fit_scores_x, py_calc_scores)
@@ -238,8 +242,8 @@ class TestFit(unittest.TestCase):
 
     def test_fit_loadings(self):
         """Compare loadings to loadings from package (P)"""
-        test_val = rmse(self.P, self.model[0].loadings_X)
-        lin_val = nan_conc_coeff(self.P, self.model[0].loadings_X)
+        test_val = rmse(self.P, self.model[0].loadings_x)
+        lin_val = nan_conc_coeff(self.P, self.model[0].loadings_x)
         with self.subTest():
             # overall rmse is low
             self.assertLess(test_val, 1e-3, msg=f"rmse = {test_val}")
@@ -318,7 +322,9 @@ class TestFit(unittest.TestCase):
         else:
             transformed_data = scaler_x.transform(in_data)
 
-        test_oomd = model.calc_oomd(transformed_data, metric=metric)
+        test_oomd = model.calc_oomd(
+            input_array=transformed_data, metric=metric
+        )
         test_val = rmse(test_oomd, known_oomd)
         lin_val = nan_conc_coeff(test_oomd, known_oomd)
 
@@ -350,11 +356,11 @@ class TestFit(unittest.TestCase):
             transformed_data_y = scaler_y.transform(self.Y)
 
         model_low = NipalsPLS(n_components=1)
-        model_low.fit(transformed_data_x, transformed_data_y)
+        model_low.fit(input_x=transformed_data_x, input_y=transformed_data_y)
 
         # Update to new amount of components
         num_lvs = model.n_components
-        model_low.set_components(num_lvs)
+        model_low.set_components(n_component=num_lvs)
 
         # compare X scores
         if self.name == "Yes NaN, PLST RandomGen":
@@ -371,8 +377,8 @@ class TestFit(unittest.TestCase):
             self.assertGreater(lin_val, 1 - 1e-5, msg=f"linConc = {lin_val}")
 
         # compare X loadings
-        test_val = rmse(model.loadings_X, model_low.loadings_X)
-        lin_val = nan_conc_coeff(model.loadings_X, model_low.loadings_X)
+        test_val = rmse(model.loadings_x, model_low.loadings_x)
+        lin_val = nan_conc_coeff(model.loadings_x, model_low.loadings_x)
         with self.subTest():
             # overall rmse is low
             self.assertLess(test_val, 1e-3, msg=f"rmse = {test_val}")
@@ -414,8 +420,8 @@ class TestFit(unittest.TestCase):
             self.assertGreater(lin_val, 1 - 1e-5, msg=f"linConc = {lin_val}")
 
         # Add an extra component, drop back down
-        model_low.set_components(num_lvs + 1)
-        model_low.set_components(num_lvs)
+        model_low.set_components(n_component=num_lvs + 1)
+        model_low.set_components(n_component=num_lvs)
 
         # compare X scores
         if self.name == "Yes NaN, PLST RandomGen":
@@ -432,8 +438,8 @@ class TestFit(unittest.TestCase):
             self.assertGreater(lin_val, 1 - 1e-5, msg=f"linConc = {lin_val}")
 
         # compare X loadings
-        test_val = rmse(self.P, model_low.loadings_X[:, :num_lvs])
-        lin_val = nan_conc_coeff(self.P, model_low.loadings_X[:, :num_lvs])
+        test_val = rmse(self.P, model_low.loadings_x[:, :num_lvs])
+        lin_val = nan_conc_coeff(self.P, model_low.loadings_x[:, :num_lvs])
         with self.subTest():
             # overall rmse is low
             self.assertLess(test_val, 1e-3, msg=f"rmse = {test_val}")
@@ -493,7 +499,9 @@ class TestFit(unittest.TestCase):
             self.assertGreater(lin_val, 1 - 1e-5, msg=f"linConc = {lin_val}")
 
         metric, known_oomd = self.oomd
-        test_oomd = model_low.calc_oomd(transformed_data_x, metric=metric)
+        test_oomd = model_low.calc_oomd(
+            input_array=transformed_data_x, metric=metric
+        )
         test_val = rmse(known_oomd, test_oomd)
         lin_val = nan_conc_coeff(test_oomd, known_oomd)
         if self.name == "Yes NaN, PLST RandomGen":


### PR DESCRIPTION
Adapted to sklearn's base class naming conventions with `X` and `y`. Methods pre-defined by the baseclass can now be called like `transform(X=...)`.